### PR TITLE
engines/http: Add support for range reads 

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -3038,6 +3038,20 @@ with the caveat that when used on the command line, they must come after the
 	turns on verbose logging from libcurl, 2 additionally enables
 	HTTP IO tracing. Default is **0**
 
+.. option:: http_range_header=bool : [http]
+
+	Use :option:`blocksize` for range reads instead of the object size for read
+	I/O.
+
+	By default, the HTTP engine treats :option:`blocksize` as the size of
+	the object to read or write, and appends the block start/end offsets to the
+	:option:`filename` to create the target object path. With this parameter
+	enabled, two changes take place: the object path will instead be the
+        filename directly for both read and write I/O, and blocksize and
+        :option:`offset` will be used to set the "Range" header on read
+        requests to issue partial reads of the object.  The blocksize is still
+        used to set the size of the object for writes.
+
 .. option:: uri=str : [nbd]
 
 	Specify the NBD URI of the server to test.  The string

--- a/engines/http.c
+++ b/engines/http.c
@@ -643,7 +643,7 @@ static enum fio_q_status fio_http_queue(struct thread_data *td,
 
 	fio_ro_check(td, io_u);
 	memset(&_curl_stream, 0, sizeof(_curl_stream));
-	snprintf(object, sizeof(object), "%s_%llu_%llu", td->files[0]->file_name,
+	snprintf(object, sizeof(object), "%s_%llu_%llu", io_u->file->file_name,
 		io_u->offset, io_u->xfer_buflen);
 	if (o->https == FIO_HTTPS_OFF)
 		snprintf(url, sizeof(url), "http://%s%s", o->host, object);


### PR DESCRIPTION
The existing HTTP implementation treated blocks as individual objects
when reading and writing. This is useful in as far as it enables read
and write symmetry -- object stores generally don't allow writes to
individual ranges of objects like file systems do with files, so
treating blocks as objects is a practical way to replicate block reads
and writes.

Reading of object ranges, on the other hand, is widely supported by
object stores with the "Range" HTTP header. This change adds a parameter
which alters fio's object conventions to issue reads using the block
size and offset parameters more like file IO. When enabled, both reads
and writes will use the plain filename as the object path to issue IO.
Reads will add a "Range: bytes=<start>-<end>" header to the requests,
where the start and end positions are determined by the blocksize and
offset of the benchmark. Aside from the object path, writes are
unchanged for simplicity: the object size is determined by blocksize as
before.